### PR TITLE
Add Support for Blacklisting Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ A single, simple, out of the box python file to mass download e621 images.
 
 The only requirement is Python 3.
 
-To use, simply extract the files, delete downloads/deleteme.txt and edit tags.txt to your liking.  
-In tags.txt, type the tags you would like to download against, with each line on the file representing a single set of tags to search against (as you would type them in e621's search).  
+To use, simply extract the files, delete downloads/deleteme.txt and edit tags.txt and blacklist.txt to your liking.  
+In tags.txt, type the tags you would like to download against, with each line in the file representing a single set of tags to search against (as you would type them in e621's search).  
+In blacklist.txt, type the tags that you would like to avoid when downloading, with each line in the file representing a single tag to avoid (as you would type them in e621's search). If you don't want to blacklist any tags, simply remove the placeholder text from this file.
 Now run e621.py
 
 This will create a file called files.dat.  

--- a/blacklist.txt
+++ b/blacklist.txt
@@ -1,0 +1,1 @@
+Replace this with tags that you'd like avoid when downloading, one line per tag.

--- a/e621.py
+++ b/e621.py
@@ -4,14 +4,17 @@ import os
 import sys
 
 # Declare and initialize constants to represent the file paths for tags.txt
-# (tag lists to download against) and files.dat (database of posts that have
-# already been downloaded).
+# (tag lists to download against), blacklist.txt (a list of tags to avoid
+# when downloading posts), and files.dat (database of posts that have already
+# been downloaded).
 TAGS_TXT_FILE_PATH = os.path.join(os.getcwd(), "tags.txt")
+BLACKLIST_TXT_FILE_PATH = os.path.join(os.getcwd(), "blacklist.txt")
 FILES_DAT_FILE_PATH = os.path.join(os.getcwd(), "files.dat")
 
 page = 1
 limit = 75
 tags = []
+blacklist = []
 headers={'User-Agent':"Tag_Downloader"}
 dbappend = []
 
@@ -31,10 +34,35 @@ except:
     input("Press Enter to quit...")
     quit(-1)
 
+# Read the set of blacklisted tags from blacklist.txt. If blacklist.txt does
+# not exist, create it read in the blacklist as an empty list.
+try:
+    f = open(BLACKLIST_TXT_FILE_PATH, 'r')
+    blacklist = f.readlines()
+    f.close()
+
+    if not blacklist:
+        raise ValueError
+except:
+    f = open(BLACKLIST_TXT_FILE_PATH, 'w')
+    f.close()
+    f = open(BLACKLIST_TXT_FILE_PATH, 'r')
+    blacklist = f.readlines()
+    f.close()
+
 # Prepare all tag lists for use in requests against e621 by replacing spaces
 # with URL-encoded space ("%20") and stripping out newlines.
 for index, item in enumerate(tags):
     tags[index] = item.replace(" ", "%20").replace("\n", "")
+
+# Prepare blacklist for use in processing responses from e621 by replacing
+# spaces with URL-encoded space ("%20") and stripping out newlines.
+for index, item in enumerate(blacklist):
+    blacklist[index] = item.replace("\n", "")
+
+# Convert the blacklist list to a set. This will eliminate the need to do this
+# conversion on the fly later.
+blacklist = set(blacklist)
 
 # Open the database of posts that have already been downloaded, or create
 # it if it doesn't already exist.
@@ -98,25 +126,44 @@ for tag_list in tags:
                 print("Post #" + str(jsondata["posts"][i]["id"]) + " already exists!")
                 continue
 
-            # Download the post, reporting details about the post as it's downloaded.
-            print("Downloading post #" + str(jsondata["posts"][i]["id"]) + ".")
-            print(i)
-            print(jsondata["posts"][i]["file"])
-            url = jsondata["posts"][i]["file"]["url"]
-            if not url:
-                md5 = jsondata["posts"][i]["file"]["md5"]
-                url = "https://static1.e621.net/data/"+md5[0:2]+"/"+md5[2:4]+"/"+md5+"."+jsondata["posts"][i]["file"]["ext"]
-            print(url)
-            request=urllib.request.Request(url,None,headers)
+            # Check whether the post's tags include any blacklisted tags. If
+            # the post isn't tagged with one or more blacklisted tags, proceed
+            # to delete it. Otherwise, skip the download and move on to the
+            # next post.
+            if(
+                len(list(blacklist & set(jsondata["posts"][i]["tags"]["general"]))) == 0 and
+                len(list(blacklist & set(jsondata["posts"][i]["tags"]["artist"]))) == 0 and
+                len(list(blacklist & set(jsondata["posts"][i]["tags"]["contributor"]))) == 0 and
+                len(list(blacklist & set(jsondata["posts"][i]["tags"]["copyright"]))) == 0 and
+                len(list(blacklist & set(jsondata["posts"][i]["tags"]["character"]))) == 0 and
+                len(list(blacklist & set(jsondata["posts"][i]["tags"]["species"]))) == 0 and
+                len(list(blacklist & set(jsondata["posts"][i]["tags"]["meta"]))) == 0 and
+                len(list(blacklist & set(jsondata["posts"][i]["tags"]["lore"]))) == 0
+            ):
+                # Download the post, reporting details about the post as it's downloaded.
+                print("Downloading post #" + str(jsondata["posts"][i]["id"]) + ".")
+                print(i)
+                print(jsondata["posts"][i]["file"])
+                url = jsondata["posts"][i]["file"]["url"]
+                if not url:
+                    md5 = jsondata["posts"][i]["file"]["md5"]
+                    url = "https://static1.e621.net/data/"+md5[0:2]+"/"+md5[2:4]+"/"+md5+"."+jsondata["posts"][i]["file"]["ext"]
+                print(url)
+                request=urllib.request.Request(url,None,headers)
 
-            f = open(os.path.join(os.getcwd(), "downloads", str(jsondata["posts"][i]["id"]) + "." + jsondata["posts"][i]["file"]["ext"]), 'wb')
-            f.write(urllib.request.urlopen(request).read())
-            f.close
+                f = open(os.path.join(os.getcwd(), "downloads", str(jsondata["posts"][i]["id"]) + "." + jsondata["posts"][i]["file"]["ext"]), 'wb')
+                f.write(urllib.request.urlopen(request).read())
+                f.close
 
-            # Add the post's identifier to a list of downloaded posts, which
-            # will be added to the database of posts that have already been
-            # downloaded later.
-            dbappend.append(str(jsondata["posts"][i]["id"]))
+                # Add the post's identifier to a list of downloaded posts, which
+                # will be added to the database of posts that have already been
+                # downloaded later.
+                dbappend.append(str(jsondata["posts"][i]["id"]))
+            else:
+                # If the post includes a blacklisted tag, skip the download
+                # step (and move on to the next post).
+                print("Post #" + str(jsondata["posts"][i]["id"]) + " contains one or more blacklisted tags!")
+                continue
 
         # Open the database of posts that have already been downloaded so the
         # set of newly-downloaded posts can be added to it.

--- a/e621.py
+++ b/e621.py
@@ -94,7 +94,13 @@ for tag_list in tags:
     # processed when processing multiple tag lists.
     page = 1
 
-    while True:
+    # Iterate over the set of result pages returned by e621 and download the
+    # posts on each page. This loop is set to terminate in the event that 750
+    # pages are processed due to how e621 handles pagination for queries that
+    # return more than 750 pages of posts (the pagination strategy changes with
+    # page 751 and the pattern for page numbering at this point hasn't yet been
+    # identified).
+    while True and page < 751:
         # Build the request URL using the current tag list, page number, and
         # page post limit.
         url = "https://e621.net/posts.json?tags={}&page={}&limit={}".format(tag_list, page, limit)


### PR DESCRIPTION
## Overview

Adds support for blacklisting tags from a "global" blacklist (`blacklist.txt`) without requiring the user to manually specify exclusions for these tags in `tags.txt`. This functionality is similar to the blacklist feature on the e621 website in that the script will skip downloads for posts which contain one or more blacklisted tags.

This is especially useful in cases where users have one or more tags that they never want to see, especially when users are downloading large volumes of posts or using broad tag sets.

To use the blacklist, users just need to add each tag that they would like to blacklist to its own line in `blacklist.txt` (one tag per line).

When the script encounters a post tagged with one or more blacklisted tags, it will print a message indicating that it is skipping the download for the post for that reason.